### PR TITLE
WIP: Add Mesos Operator API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,8 @@
 deps
 doc
 proto
-include/scheduler_protobuf.hrl
-src/scheduler_protobuf.erl
-include/executor_protobuf.hrl
-src/executor_protobuf.erl
+include/*_protobuf.hrl
+src/*_protobuf.erl
 ebin
 logs
 *.beam

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ deps:
 clean:
 	$(REBAR) clean
 
+protoclean:
+	-rm -rf $(BASE_DIR)/proto
+	-rm $(BASE_DIR)/include/*_protobuf.hrl
+	-rm $(BASE_DIR)/src/*_protobuf.erl
+
 distclean: clean
 	$(REBAR) delete-deps
 

--- a/include/agent_info.hrl
+++ b/include/agent_info.hrl
@@ -1,0 +1,5 @@
+-record(agent_info, {data_format :: erl_mesos_data_format:data_format(),
+                     data_format_module :: module(),
+                     api_version :: erl_mesos_scheduler_call:version(),
+                     request_options :: erl_mesos_http:options(),
+                     agent_host :: binary()}).

--- a/include/master_info.hrl
+++ b/include/master_info.hrl
@@ -1,0 +1,6 @@
+-record(master_info, {data_format :: erl_mesos_data_format:data_format(),
+                      data_format_module :: module(),
+                      api_version :: erl_mesos_scheduler_call:version(),
+                      master_host :: binary(),
+                      request_options :: erl_mesos_http:options(),
+                      subscribed :: boolean()}).

--- a/proto.sh
+++ b/proto.sh
@@ -35,22 +35,30 @@ sed -e 's/message Request/message Req/' ${SCHEDULER} > ${SCHEDULER}.tmp && mv ${
 sed -e 's/repeated mesos.v1.Request/repeated Request/' ${SCHEDULER} > ${SCHEDULER}.tmp && mv ${SCHEDULER}.tmp ${SCHEDULER}
 sed -e 's/optional Request/optional Req/' ${SCHEDULER} > ${SCHEDULER}.tmp && mv ${SCHEDULER}.tmp ${SCHEDULER}
 
+# Rebar2
+GPB=${PARENT}/deps/gpb/ebin
+
+if [ ! -d "${GPB}" ]; then
+    # Rebar3
+    GPB=${PARENT}/../gpb/ebin
+fi
+
 # Compile master.proto
-erl +B -noinput -pa ${PARENT}/deps/gpb/ebin\
+erl +B -noinput -pa ${GPB}\
     -I${PARENT}/proto -o-erl src -o-hrl include -modsuffix _protobuf -il\
     -s gpb_compile c ${MASTER}
 
 # Compile agent.proto
-erl +B -noinput -pa ${PARENT}/deps/gpb/ebin\
+erl +B -noinput -pa ${GPB}\
     -I${PARENT}/proto -o-erl src -o-hrl include -modsuffix _protobuf -il\
     -s gpb_compile c ${AGENT}
 
 # Compile scheduler.proto
-erl +B -noinput -pa ${PARENT}/deps/gpb/ebin\
+erl +B -noinput -pa ${GPB}\
     -I${PARENT}/proto -o-erl src -o-hrl include -modsuffix _protobuf -il\
     -s gpb_compile c ${SCHEDULER}
 
 # Compile executor.proto
-erl +B -noinput -pa ${PARENT}/deps/gpb/ebin\
+erl +B -noinput -pa ${GPB}\
     -I${PARENT}/proto -o-erl src -o-hrl include -modsuffix _protobuf -il\
     -s gpb_compile c ${EXECUTOR}

--- a/proto.sh
+++ b/proto.sh
@@ -7,16 +7,43 @@ URL_PREFIX=https://raw.githubusercontent.com/apache/mesos
 # Download proto files
 mkdir -p ${PARENT}/proto/mesos/v1/scheduler
 wget -q -N ${URL_PREFIX}/${VSN}/include/mesos/v1/mesos.proto -P ${PARENT}/proto/mesos/v1
+wget -q -N ${URL_PREFIX}/${VSN}/include/mesos/v1/quota/quota.proto -P ${PARENT}/proto/mesos/v1/quota
+wget -q -N ${URL_PREFIX}/${VSN}/include/mesos/v1/allocator/allocator.proto -P ${PARENT}/proto/mesos/v1/allocator
+wget -q -N ${URL_PREFIX}/${VSN}/include/mesos/v1/maintenance/maintenance.proto -P ${PARENT}/proto/mesos/v1/maintenance
+wget -q -N ${URL_PREFIX}/${VSN}/include/mesos/v1/master/master.proto -P ${PARENT}/proto/mesos/v1/master
+wget -q -N ${URL_PREFIX}/${VSN}/include/mesos/v1/agent/agent.proto -P ${PARENT}/proto/mesos/v1/agent
 wget -q -N ${URL_PREFIX}/${VSN}/include/mesos/v1/scheduler/scheduler.proto -P ${PARENT}/proto/mesos/v1/scheduler
 wget -q -N ${URL_PREFIX}/${VSN}/include/mesos/v1/executor/executor.proto -P ${PARENT}/proto/mesos/v1/executor
 
+MASTER=${PARENT}/proto/mesos/v1/master/master.proto
+AGENT=${PARENT}/proto/mesos/v1/agent/agent.proto
+MAINT=${PARENT}/proto/mesos/v1/maintenance/maintenance.proto
 SCHEDULER=${PARENT}/proto/mesos/v1/scheduler/scheduler.proto
 EXECUTOR=${PARENT}/proto/mesos/v1/executor/executor.proto
+
+# Fix mater.proto
+sed -e 's/required maintenance.Schedule/repeated Schedule/' ${MASTER} > ${MASTER}.tmp && mv ${MASTER}.tmp ${MASTER}
+sed -e 's/required quota.QuotaRequest/required QuotaRequest/' ${MASTER} > ${MASTER}.tmp && mv ${MASTER}.tmp ${MASTER}
+sed -e 's/required maintenance.ClusterStatus/required ClusterStatus/' ${MASTER} > ${MASTER}.tmp && mv ${MASTER}.tmp ${MASTER}
+sed -e 's/required quota.QuotaStatus/required QuotaStatus/' ${MASTER} > ${MASTER}.tmp && mv ${MASTER}.tmp ${MASTER}
+
+# Fix maintenance.proto
+sed -e 's/repeated allocator.InverseOfferStatus/repeated InverseOfferStatus/' ${MAINT} > ${MAINT}.tmp && mv ${MAINT}.tmp ${MAINT}
 
 # Fix scheduler.proto
 sed -e 's/message Request/message Req/' ${SCHEDULER} > ${SCHEDULER}.tmp && mv ${SCHEDULER}.tmp ${SCHEDULER}
 sed -e 's/repeated mesos.v1.Request/repeated Request/' ${SCHEDULER} > ${SCHEDULER}.tmp && mv ${SCHEDULER}.tmp ${SCHEDULER}
 sed -e 's/optional Request/optional Req/' ${SCHEDULER} > ${SCHEDULER}.tmp && mv ${SCHEDULER}.tmp ${SCHEDULER}
+
+# Compile master.proto
+erl +B -noinput -pa ${PARENT}/deps/gpb/ebin\
+    -I${PARENT}/proto -o-erl src -o-hrl include -modsuffix _protobuf -il\
+    -s gpb_compile c ${MASTER}
+
+# Compile agent.proto
+erl +B -noinput -pa ${PARENT}/deps/gpb/ebin\
+    -I${PARENT}/proto -o-erl src -o-hrl include -modsuffix _protobuf -il\
+    -s gpb_compile c ${AGENT}
 
 # Compile scheduler.proto
 erl +B -noinput -pa ${PARENT}/deps/gpb/ebin\

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [{hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.6.0"}}},
         {gpb, ".*", {git, "git://github.com/tomas-abrahamsson/gpb.git", {tag, "3.22.3"}}}]}.
 
-{pre_hooks, [{compile, "./proto.sh 1.0.0"}]}.
+{pre_hooks, [{compile, "./proto.sh 1.0.1"}]}.

--- a/src/erl_mesos.erl
+++ b/src/erl_mesos.erl
@@ -28,6 +28,8 @@
 
 -export([start_scheduler/4, start_scheduler/5, stop_scheduler/1]).
 
+-export([start_master/4, start_master/5, stop_master/1]).
+
 -export([start/2, stop/1]).
 
 -type 'AgentID'() :: #'AgentID'{}.
@@ -132,6 +134,28 @@ start_scheduler(Ref, Scheduler, SchedulerOptions, Options, Timeout) ->
 -spec stop_scheduler(term())  -> ok | {error, term()}.
 stop_scheduler(Ref) ->
     erl_mesos_scheduler_manager:stop_scheduler(Ref).
+
+%% @equiv erl_mesos:start_master(Ref, Master, MasterOptions, Options,
+%%                                  infinity)
+-spec start_master(term(), module(), term(),
+                   erl_mesos_master:options()) ->
+                          {ok, pid()} | {error, term()}.
+start_master(Ref, Master, MasterOptions, Options) ->
+    start_master(Ref, Master, MasterOptions, Options, infinity).
+
+%% @doc Starts master operator API client.
+-spec start_master(term(), module(), term(),
+                   erl_mesos_master:options(), timeout()) ->
+                          {ok, pid()} | {error, term()}.
+start_master(Ref, Master, MasterOptions, Options, Timeout) ->
+    erl_mesos_master_manager:start_master(Ref, Master,
+                                                MasterOptions, Options,
+                                                Timeout).
+
+%% @doc Stops master.
+-spec stop_master(term())  -> ok | {error, term()}.
+stop_master(Ref) ->
+    erl_mesos_master_manager:stop_master(Ref).
 
 %% application callback functions.
 

--- a/src/erl_mesos_agent.erl
+++ b/src/erl_mesos_agent.erl
@@ -1,0 +1,374 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License. You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(erl_mesos_agent).
+
+-behaviour(gen_server).
+
+-include("agent_info.hrl").
+
+-include("agent_protobuf.hrl").
+
+-export([start_link/4]).
+
+-export([get_version/1,
+         get_state/1,
+         get_frameworks/1,
+         get_executors/1,
+         get_tasks/1,
+         get_containers/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3,
+         format_status/2]).
+
+-record(state, {ref :: term(),
+                agent :: module(),
+                data_format :: erl_mesos_data_format:data_format(),
+                data_format_module :: module(),
+                api_version :: erl_mesos_agent_call:version(),
+                agent_host :: binary(),
+                request_options :: erl_mesos_http:options(),
+                agent_state :: undefined | term()}).
+
+-type options() :: [{atom(), term()}].
+-export_type([options/0]).
+
+-type 'Call'() :: #'Call'{}.
+-export_type(['Call'/0]).
+
+-type 'Call.GetMetrics'() :: #'Call.GetMetrics'{}.
+-export_type(['Call.GetMetrics'/0]).
+
+-type 'Call.SetLoggingLevel'() :: #'Call.SetLoggingLevel'{}.
+-export_type(['Call.SetLoggingLevel'/0]).
+
+-type 'Call.ListFiles'() :: #'Call.ListFiles'{}.
+-export_type(['Call.ListFiles'/0]).
+
+-type 'Call.ReadFile'() :: #'Call.ReadFile'{}.
+-export_type(['Call.ReadFile'/0]).
+
+-type agent_info() :: #agent_info{}.
+-export_type([agent_info/0]).
+
+-type state() :: #state{}.
+
+%% Callbacks.
+
+-callback init(term()) ->
+    {ok, term()} | {stop, term()}.
+
+-callback handle_info(agent_info(), term(), term()) ->
+    {ok, term()} | {stop, term()}.
+
+-callback terminate(agent_info(), term(), term()) -> term().
+
+-define(DEFAULT_AGENT_HOST, <<"localhost:5051">>).
+
+-define(DEFAULT_REQUEST_OPTIONS, []).
+
+-define(DEFAULT_RECV_TIMEOUT, 5000).
+
+-define(DEFAULT_MAX_REDIRECT, 5).
+
+-define(DEFAULT_MAX_NUM_RESUBSCRIBE, 1).
+
+-define(DEFAULT_RESUBSCRIBE_INTERVAL, 0).
+
+-define(DATA_FORMAT, protobuf).
+
+-define(DATA_FORMAT_MODULE, master_protobuf).
+
+-define(API_VERSION, v1).
+
+%% External functions.
+
+%% @doc Starts the `erl_mesos_master' process.
+-spec start_link(term(), module(), term(), options()) ->
+    {ok, pid()} | {error, term()}.
+start_link(Ref, Agent, AgentOptions, Options) ->
+    gen_server:start_link(?MODULE, {Ref, Agent, AgentOptions, Options},
+                          []).
+
+%% @doc GetVersion call.
+-spec get_version(agent_info()) -> term() | {error, term()}.
+get_version(AgentInfo) ->
+    erl_mesos_agent_call:get_version(AgentInfo).
+
+%% @doc GetState call.
+-spec get_state(agent_info()) -> term() | {error, term()}.
+get_state(AgentInfo) ->
+    erl_mesos_agent_call:get_state(AgentInfo).
+
+%% @doc GetFrameworks call.
+-spec get_frameworks(agent_info()) -> term() | {error, term()}.
+get_frameworks(AgentInfo) ->
+    erl_mesos_agent_call:get_frameworks(AgentInfo).
+
+%% @doc GetExecutors call.
+-spec get_executors(agent_info()) -> term() | {error, term()}.
+get_executors(AgentInfo) ->
+    erl_mesos_agent_call:get_executors(AgentInfo).
+
+%% @doc GetTasks call.
+-spec get_tasks(agent_info()) -> term() | {error, term()}.
+get_tasks(AgentInfo) ->
+    erl_mesos_agent_call:get_tasks(AgentInfo).
+
+%% @doc GetContainers call.
+-spec get_containers(agent_info()) -> term() | {error, term()}.
+get_containers(AgentInfo) ->
+    erl_mesos_agent_call:get_containers(AgentInfo).
+
+%% GET_HEALTH
+%% GET_FLAGS
+%% GET_METRICS
+%% GET_LOGGING_LEVEL
+%% SET_LOGGING_LEVEL
+%% LIST_FILES
+%% READ_FILE
+%% LAUNCH_NESTED_CONTAINER
+%% WAIT_NESTED_CONTAINER
+%% KILL_NESTED_CONTAINER
+%% LAUNCH_NESTED_CONTAINER_SESSION
+%% ATTACH_CONTAINER_INPUT
+%% ATTACH_CONTAINER_OUTPUT
+
+%% gen_server callback functions.
+
+%% @private
+-spec init({term(), module(), term(), options()}) ->
+    {ok, state()} | {stop, term()}.
+init({Ref, Agent, AgentOptions, Options}) ->
+    case init(Ref, Agent, AgentOptions, Options) of
+        {ok, State} ->
+            {ok, State};
+        {error, Reason} ->
+            {stop, Reason}
+    end.
+
+%% @private
+-spec handle_call(term(), {pid(), term()}, state()) -> {noreply, state()}.
+handle_call(Request, _From, State) ->
+    log_warning("Agent received unexpected call request.", "Request: ~p.",
+                [Request], State),
+    {noreply, State}.
+
+%% @private
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(Request, State) ->
+    log_warning("Agent received unexpected cast request.", "Request: ~p.",
+                [Request], State),
+    {noreply, State}.
+
+%% @private
+-spec handle_info(term(), state()) ->
+    {noreply, state()} | {stop, term(), state()}.
+handle_info(Info, State) ->
+    log_warning("Agent received unexpected handle info request.", "Request: ~p.",
+                [Info], State),
+    {noreply, State}.
+
+%% @private
+-spec terminate(term(), state()) -> term().
+terminate(Reason, #state{agent = Agent,
+                         agent_state = AgentState} = State) ->
+    AgentInfo = agent_info(State),
+    Agent:terminate(AgentInfo, Reason, AgentState).
+
+%% @private
+-spec code_change(term(), state(), term()) -> {ok, state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% @private
+-spec format_status(normal | terminate, [{atom(), term()} | state()]) ->
+    [{atom(), term()}].
+format_status(normal, [_Dict, State]) ->
+    [{data, [{"State", format_state(State)}]}];
+format_status(terminate, [_Dict, State]) ->
+    format_state(State).
+
+%% Internal functions.
+
+%% @doc Validates options and sets options to the state.
+%% @private
+-spec init(term(), module(), term(), options()) ->
+    {ok, state()} | {error, term()}.
+init(Ref, Agent, AgentOptions, Options) ->
+    Funs = [fun agent_host/1,
+            fun request_options/1],
+    case options(Funs, Options) of
+        {ok, ValidOptions} ->
+            State = state(Ref, Agent, ValidOptions),
+            case init(AgentOptions, State) of
+                {ok, State1} ->
+                    {ok, State1};
+                {stop, Reason} ->
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Returns agent host.
+%% @private
+-spec agent_host(options()) ->
+    {ok, {agent_host, [binary()]}} | {error, {bad_agent_host, term()}} |
+    {error, {bad_agent_host, term()}}.
+agent_host(Options) ->
+    case proplists:get_value(agent_host, Options, ?DEFAULT_AGENT_HOST) of
+        AgentHost when is_list(AgentHost) -> list_to_binary(AgentHost);
+        AgentHost when is_binary(AgentHost) -> AgentHost;
+        AgentHosts ->
+            {error, {bad_agent_host, AgentHosts}}
+    end.
+
+%% @doc Returns request options.
+%% @private
+-spec request_options(options()) ->
+    {ok, {request_options, [{atom(), term()}]}} |
+    {error, {bad_request_options, term()}}.
+request_options(Options) ->
+    case proplists:get_value(request_options, Options,
+                             ?DEFAULT_REQUEST_OPTIONS) of
+        RequestOptions when is_list(RequestOptions) ->
+            {ok, {request_options, RequestOptions}};
+        RequestOptions ->
+            {error, {bad_request_options, RequestOptions}}
+    end.
+
+%% @doc Returns validated options.
+%% @private
+-spec options([fun((options()) -> {ok, {atom(), term()}} | {error, term()})],
+              options()) ->
+    {ok, options()} | {error, term()}.
+options(Funs, Options) when is_list(Options) ->
+    options(Funs, Options, []);
+options(_Funs, Options) ->
+    {error, {bad_options, Options}}.
+
+%% @doc Returns validated options.
+%% @private
+-spec options([fun((options()) -> {ok, {atom(), term()}} | {error, term()})],
+              options(), options()) ->
+    {ok, options()} | {error, term()}.
+options([Fun | Funs], Options, ValidOptions) ->
+    case Fun(Options) of
+        {ok, Option} ->
+            options(Funs, Options, [Option | ValidOptions]);
+        {error, Reason} ->
+            {error, Reason}
+    end;
+options([], _Options, ValidOptions) ->
+    {ok, ValidOptions}.
+
+%% @doc Returns state.
+%% @private
+-spec state(term(), module(), options()) -> state().
+state(Ref, Agent, Options) ->
+    AgentHost = proplists:get_value(agent_host, Options),
+    RequestOptions = proplists:get_value(request_options, Options),
+    #state{ref = Ref,
+           agent = Agent,
+           data_format = ?DATA_FORMAT,
+           data_format_module = ?DATA_FORMAT_MODULE,
+           api_version = ?API_VERSION,
+           agent_host = AgentHost,
+           request_options = RequestOptions}.
+
+%% @doc Calls Agent:init/1.
+%% @private
+-spec init(term(), state()) -> {ok, state()} | {stop, term()}.
+init(AgentOptions, #state{agent = Agent} = State) ->
+    case Agent:init(AgentOptions) of
+        {ok, AgentState} ->
+            {ok, State#state{agent_state = AgentState}};
+        {stop, Reason} ->
+            {stop, Reason}
+    end.
+
+%% @doc Returns master info.
+%% @private
+-spec agent_info(state()) -> agent_info().
+agent_info(#state{data_format = DataFormat,
+                   data_format_module = DataFormatModule,
+                   api_version = ApiVersion,
+                   agent_host = AgentHost,
+                   request_options = RequestOptions}) ->
+    #agent_info{data_format = DataFormat,
+                 data_format_module = DataFormatModule,
+                 api_version = ApiVersion,
+                 agent_host = AgentHost,
+                 request_options = RequestOptions}.
+
+%% @doc Logs info.
+%% @private
+%% -spec log_info(string(), string(), [term()], state()) -> ok.
+%% log_info(Message, Format, Data, #state{ref = Ref, agent = Agent}) ->
+%%     erl_mesos_logger:info(Message ++ " Ref: ~p, Agent: ~p, " ++ Format,
+%%                           [Ref, Agent | Data]).
+
+%% @doc Logs warning.
+%% @private
+-spec log_warning(string(), string(), [term()], state()) -> ok.
+log_warning(Message, Format, Data, #state{ref = Ref, agent = Agent}) ->
+    erl_mesos_logger:warning(Message ++ " Ref: ~p, Agent: ~p, " ++ Format,
+                             [Ref, Agent | Data]).
+
+%% @doc Logs error.
+%% @private
+%% -spec log_error(string(), state()) -> ok.
+%% log_error(Message, #state{ref = Ref, agent = Agent}) ->
+%%     erl_mesos_logger:error(Message ++ " Ref: ~p, Agent: ~p.",
+%%                            [Ref, Agent]).
+
+%% @doc Logs error.
+%% @private
+%% -spec log_error(string(), string(), [term()], state()) -> ok.
+%% log_error(Message, Format, Data, #state{ref = Ref, agent = Agent}) ->
+%%     erl_mesos_logger:error(Message ++ " Ref: ~p, Agent: ~p, " ++ Format,
+%%                            [Ref, Agent | Data]).
+
+%% @doc Formats state.
+%% @private
+-spec format_state(state()) -> [{string(), [{atom(), term()}]}].
+format_state(#state{ref = Ref,
+                    agent = Agent,
+                    data_format = DataFormat,
+                    data_format_module = DataFormatModule,
+                    api_version = ApiVersion,
+                    agent_host = AgentHost,
+                    request_options = RequestOptions,
+                    agent_state = AgentState}) ->
+    State = [{data_format, DataFormat},
+             {data_format_module, DataFormatModule},
+             {api_version, ApiVersion},
+             {agent_host, AgentHost},
+             {request_options, RequestOptions}],
+    [{"Ref", Ref},
+     {"Agent", Agent},
+     {"Agent state", AgentState},
+     {"State", State}].

--- a/src/erl_mesos_agent_call.erl
+++ b/src/erl_mesos_agent_call.erl
@@ -1,0 +1,101 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License. You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @private
+
+-module(erl_mesos_agent_call).
+
+-include("agent_info.hrl").
+
+-include("master_protobuf.hrl").
+
+-export([get_version/1,
+         get_state/1,
+         get_frameworks/1,
+         get_executors/1,
+         get_tasks/1,
+         get_containers/1]).
+
+-type version() :: v1.
+-export_type([version/0]).
+
+-define(V1_API_PATH, "/api/v1").
+
+%% External functions.
+
+%% @doc Executes GetVersion call.
+-spec get_version(erl_mesos_agent:agent_info()) -> term() | {error, term()}.
+get_version(AgentInfo) ->
+    Call = #'Call'{type = 'GET_VERSION'},
+    sync_request(AgentInfo, Call).
+
+%% @doc Executes GetState call.
+-spec get_state(erl_mesos_agent:agent_info()) -> term() | {error, term()}.
+get_state(AgentInfo) ->
+    Call = #'Call'{type = 'GET_STATE'},
+    sync_request(AgentInfo, Call).
+
+%% @doc Executes GetFrameworks call.
+-spec get_frameworks(erl_mesos_agent:agent_info()) -> term() | {error, term()}.
+get_frameworks(AgentInfo) ->
+    Call = #'Call'{type = 'GET_FRAMEWORKS'},
+    sync_request(AgentInfo, Call).
+
+%% @doc Executes GetExecutors call.
+-spec get_executors(erl_mesos_agent:agent_info()) -> term() | {error, term()}.
+get_executors(AgentInfo) ->
+    Call = #'Call'{type = 'GET_EXECUTORS'},
+    sync_request(AgentInfo, Call).
+
+%% @doc Executes GetTasks call.
+-spec get_tasks(erl_mesos_agent:agent_info()) -> term() | {error, term()}.
+get_tasks(AgentInfo) ->
+    Call = #'Call'{type = 'GET_TASKS'},
+    sync_request(AgentInfo, Call).
+
+%% @doc Executes GetContainers call.
+-spec get_containers(erl_mesos_agent:agent_info()) -> term() | {error, term()}.
+get_containers(AgentInfo) ->
+    Call = #'Call'{type = 'GET_CONTAINERS'},
+    sync_request(AgentInfo, Call).
+
+%% Internal functions.
+
+%% @doc Sends sync http request.
+%% @private
+-spec sync_request(erl_mesos_agent:agent_info(),
+                   erl_mesos_scheduler:'Call'()) ->
+    ok | {error, term()}.
+sync_request(#agent_info{data_format = DataFormat,
+                          data_format_module = DataFormatModule,
+                          api_version = ApiVersion,
+                          agent_host = AgentHost,
+                          request_options = RequestOptions}, Call) ->
+    ReqUrl = request_url(ApiVersion, AgentHost),
+    ReqHeaders = [],
+    Response = erl_mesos_http:sync_request(ReqUrl, DataFormat, DataFormatModule,
+                                           ReqHeaders, Call, RequestOptions),
+    erl_mesos_http:handle_sync_response(Response).
+
+%% @doc Returns request url.
+%% @private
+-spec request_url(version(), binary()) -> binary().
+request_url(v1, AgentHost) ->
+    <<"http://", AgentHost/binary, ?V1_API_PATH>>.

--- a/src/erl_mesos_http.erl
+++ b/src/erl_mesos_http.erl
@@ -94,6 +94,13 @@ handle_sync_response(Response) ->
                 {error, Reason} ->
                     {error, Reason}
             end;
+        {ok, 200, _Headers, ClientRef} ->
+            case body(ClientRef) of
+                {ok, Body} ->
+                    {ok, Body};
+                {error, Reason} ->
+                    {error, Reason}
+            end;
         {ok, Status, _Headers, ClientRef} ->
             case body(ClientRef) of
                 {ok, Body} ->

--- a/src/erl_mesos_master.erl
+++ b/src/erl_mesos_master.erl
@@ -1,0 +1,959 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License. You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(erl_mesos_master).
+
+-behaviour(gen_server).
+
+-include("master_info.hrl").
+
+-include("master_protobuf.hrl").
+
+-export([start_link/4]).
+
+-export([get_version/1,
+         get_state/1,
+         get_agents/1,
+         get_frameworks/1,
+         get_executors/1,
+         get_tasks/1,
+         get_roles/1,
+         get_master/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3,
+         format_status/2]).
+
+-record(state, {ref :: term(),
+                master :: module(),
+                data_format :: erl_mesos_data_format:data_format(),
+                data_format_module :: module(),
+                api_version :: erl_mesos_master_call:version(),
+                master_hosts :: [binary()],
+                request_options :: erl_mesos_http:options(),
+                max_num_resubscribe :: non_neg_integer(),
+                resubscribe_interval :: non_neg_integer(),
+                registered = false :: boolean(),
+                call_subscribe :: undefined | 'Event.Subscribed'(),
+                master_state :: undefined | term(),
+                master_hosts_queue :: undefined | [binary()],
+                master_host :: undefined | binary(),
+                client_ref :: undefined | erl_mesos_http:client_ref(),
+                recv_timer_ref :: undefined | reference(),
+                subscribe_state :: undefined | subscribe_state(),
+                num_redirect = 0 :: non_neg_integer(),
+                num_resubscribe = 0 :: non_neg_integer(),
+                resubscribe_timer_ref :: undefined | reference()}).
+
+-record(subscribe_response, {status :: undefined | non_neg_integer(),
+                             headers :: undefined | erl_mesos_http:headers()}).
+
+-type options() :: [{atom(), term()}].
+-export_type([options/0]).
+
+-type 'Call'() :: #'Call'{}.
+-export_type(['Call'/0]).
+
+-type 'Call.GetMetrics'() :: #'Call.GetMetrics'{}.
+-export_type(['Call.GetMetrics'/0]).
+
+-type 'Call.SetLoggingLevel'() :: #'Call.SetLoggingLevel'{}.
+-export_type(['Call.SetLoggingLevel'/0]).
+
+-type 'Call.ListFiles'() :: #'Call.ListFiles'{}.
+-export_type(['Call.ListFiles'/0]).
+
+-type 'Call.ReadFile'() :: #'Call.ReadFile'{}.
+-export_type(['Call.ReadFile'/0]).
+
+-type 'Call.UpdateWeights'() :: #'Call.UpdateWeights'{}.
+-export_type(['Call.UpdateWeights'/0]).
+
+-type 'Call.ReserveResources'() :: #'Call.ReserveResources'{}.
+-export_type(['Call.ReserveResources'/0]).
+
+-type 'Call.UnreserveResources'() :: #'Call.UnreserveResources'{}.
+-export_type(['Call.UnreserveResources'/0]).
+
+-type 'Call.CreateVolumes'() :: #'Call.CreateVolumes'{}.
+-export_type(['Call.CreateVolumes'/0]).
+
+-type 'Call.DestroyVolumes'() :: #'Call.DestroyVolumes'{}.
+-export_type(['Call.DestroyVolumes'/0]).
+
+-type 'Call.UpdateMaintenanceSchedule'() :: #'Call.UpdateMaintenanceSchedule'{}.
+-export_type(['Call.UpdateMaintenanceSchedule'/0]).
+
+-type 'Call.StartMaintenance'() :: #'Call.StartMaintenance'{}.
+-export_type(['Call.StartMaintenance'/0]).
+
+-type 'Call.StopMaintenance'() :: #'Call.StopMaintenance'{}.
+-export_type(['Call.StopMaintenance'/0]).
+
+-type 'Call.SetQuota'() :: #'Call.SetQuota'{}.
+-export_type(['Call.SetQuota'/0]).
+
+-type 'Call.RemoveQuota'() :: #'Call.RemoveQuota'{}.
+-export_type(['Call.RemoveQuota'/0]).
+
+-type 'Event'() :: #'Event'{}.
+-export_type(['Event'/0]).
+
+-type 'Event.TaskAdded'() :: #'Event.TaskAdded'{}.
+-export_type(['Event.TaskAdded'/0]).
+
+-type 'Event.TaskUpdated'() :: #'Event.TaskUpdated'{}.
+-export_type(['Event.TaskUpdated'/0]).
+
+-type 'Event.Subscribed'() :: #'Event.Subscribed'{}.
+-export_type(['Event.Subscribed'/0]).
+
+-type master_info() :: #master_info{}.
+-export_type([master_info/0]).
+
+-type state() :: #state{}.
+
+-type subscribe_response() :: subscribe_response().
+
+-type subscribe_state() :: subscribe_response() | subscribed.
+
+%% Callbacks.
+
+-callback init(term()) ->
+    {ok, term()} | {stop, term()}.
+
+-callback subscribed(master_info(), 'Event.Subscribed'(), term()) ->
+    {ok, term()} | {stop, term()}.
+
+-callback disconnected(master_info(), term()) ->
+    {ok, term()} | {stop, term()}.
+
+-callback task_added(master_info(), 'Event.TaskAdded'(), term()) ->
+    {ok, term()} | {stop, term()}.
+
+-callback task_updated(master_info(), 'Event.TaskUpdated'(), term()) ->
+    {ok, term()} | {stop, term()}.
+
+-callback handle_info(master_info(), term(), term()) ->
+    {ok, term()} | {stop, term()}.
+
+-callback terminate(master_info(), term(), term()) -> term().
+
+-define(DEFAULT_MASTER_HOSTS, [<<"localhost:5050">>]).
+
+-define(DEFAULT_REQUEST_OPTIONS, []).
+
+-define(DEFAULT_RECV_TIMEOUT, 5000).
+
+-define(DEFAULT_MAX_REDIRECT, 5).
+
+-define(DEFAULT_MAX_NUM_RESUBSCRIBE, 1).
+
+-define(DEFAULT_RESUBSCRIBE_INTERVAL, 0).
+
+-define(DATA_FORMAT, protobuf).
+
+-define(DATA_FORMAT_MODULE, master_protobuf).
+
+-define(API_VERSION, v1).
+
+%% External functions.
+
+%% @doc Starts the `erl_mesos_master' process.
+-spec start_link(term(), module(), term(), options()) ->
+    {ok, pid()} | {error, term()}.
+start_link(Ref, Master, MasterOptions, Options) ->
+    gen_server:start_link(?MODULE, {Ref, Master, MasterOptions, Options},
+                          []).
+
+%% @doc GetVersion call.
+-spec get_version(master_info()) -> term() | {error, term()}.
+get_version(MasterInfo) ->
+    erl_mesos_master_call:get_version(MasterInfo).
+
+%% @doc GetState call.
+-spec get_state(master_info()) -> term() | {error, term()}.
+get_state(MasterInfo) ->
+    erl_mesos_master_call:get_state(MasterInfo).
+
+%% @doc GetAgents call.
+-spec get_agents(master_info()) -> term() | {error, term()}.
+get_agents(MasterInfo) ->
+    erl_mesos_master_call:get_agents(MasterInfo).
+
+%% @doc GetFrameworks call.
+-spec get_frameworks(master_info()) -> term() | {error, term()}.
+get_frameworks(MasterInfo) ->
+    erl_mesos_master_call:get_frameworks(MasterInfo).
+
+%% @doc GetExecutors call.
+-spec get_executors(master_info()) -> term() | {error, term()}.
+get_executors(MasterInfo) ->
+    erl_mesos_master_call:get_executors(MasterInfo).
+
+%% @doc GetTasks call.
+-spec get_tasks(master_info()) -> term() | {error, term()}.
+get_tasks(MasterInfo) ->
+    erl_mesos_master_call:get_tasks(MasterInfo).
+
+%% @doc GetRoles call.
+-spec get_roles(master_info()) -> term() | {error, term()}.
+get_roles(MasterInfo) ->
+    erl_mesos_master_call:get_roles(MasterInfo).
+
+%% @doc GetMaster call.
+-spec get_master(master_info()) -> term() | {error, term()}.
+get_master(MasterInfo) ->
+    erl_mesos_master_call:get_master(MasterInfo).
+
+%% GET_HEALTH
+%% GET_FLAGS
+%% GET_METRICS
+%% GET_LOGGING_LEVEL
+%% SET_LOGGING_LEVEL
+%% LIST_FILES
+%% READ_FILE
+%% GET_WEIGHTS
+%% UPDATE_WEIGHTS
+%% SUBSCRIBE
+%% RESERVE_RESOURCES
+%% UNRESERVE_RESOURCES
+%% CREATE_VOLUMES
+%% DESTROY_VOLUMES
+%% GET_MAINTENANCE_STATUS
+%% GET_MAINTENANCE_SCHEDULE
+%% UPDATE_MAINTENANCE_SCHEDULE
+%% START_MAINTENANCE
+%% STOP_MAINTENANCE
+%% GET_QUOTA
+%% SET_QUOTA
+%% REMOVE_QUOTA
+
+%% gen_server callback functions.
+
+%% @private
+-spec init({term(), module(), term(), options()}) ->
+    {ok, state()} | {stop, term()}.
+init({Ref, Master, MasterOptions, Options}) ->
+    case init(Ref, Master, MasterOptions, Options) of
+        {ok, State} ->
+            {ok, State};
+        {error, Reason} ->
+            {stop, Reason}
+    end.
+
+%% @private
+-spec handle_call(term(), {pid(), term()}, state()) -> {noreply, state()}.
+handle_call(Request, _From, State) ->
+    log_warning("Master received unexpected call request.", "Request: ~p.",
+                [Request], State),
+    {noreply, State}.
+
+%% @private
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(Request, State) ->
+    log_warning("Master received unexpected cast request.", "Request: ~p.",
+                [Request], State),
+    {noreply, State}.
+
+%% @private
+-spec handle_info(term(), state()) ->
+    {noreply, state()} | {stop, term(), state()}.
+handle_info(Info, #state{client_ref = ClientRef,
+                         recv_timer_ref = RecvTimerRef,
+                         subscribe_state = SubscribeState,
+                         resubscribe_timer_ref = ResubscribeTimerRef} =
+                  State) ->
+    case erl_mesos_http:async_response(Info) of
+        {async_response, ClientRef, Response} ->
+            handle_async_response(Response, State);
+        {async_response, _ClientRef, _Response} ->
+            {noreply, State};
+        undefined ->
+            case Info of
+                {'DOWN', ClientRef, Reason} ->
+                    log_error("Client process crashed.", "Reason: ~p.",
+                              [Reason], State),
+                    handle_unsubscribe(State);
+                {timeout, RecvTimerRef, recv}
+                  when is_reference(RecvTimerRef),
+                       SubscribeState =/= subscribed ->
+                    log_error("Receive timeout occurred.", State),
+                    handle_unsubscribe(State);
+                {timeout, RecvTimerRef, recv}
+                  when is_reference(RecvTimerRef) ->
+                    {noreply, State};
+                {timeout, ResubscribeTimerRef, resubscribe}
+                  when SubscribeState =:= undefined ->
+                    resubscribe(State);
+                {timeout, ResubscribeTimerRef, resubscribe} ->
+                    {noreply, State};
+                _Info ->
+                    call_handle_info(Info, State)
+            end
+    end.
+
+%% @private
+-spec terminate(term(), state()) -> term().
+terminate(Reason, #state{client_ref = ClientRef,
+                         master = Master,
+                         master_state = MasterState} = State) ->
+    close(ClientRef),
+    MasterInfo = master_info(State),
+    Master:terminate(MasterInfo, Reason, MasterState).
+
+%% @private
+-spec code_change(term(), state(), term()) -> {ok, state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% @private
+-spec format_status(normal | terminate, [{atom(), term()} | state()]) ->
+    [{atom(), term()}].
+format_status(normal, [_Dict, State]) ->
+    [{data, [{"State", format_state(State)}]}];
+format_status(terminate, [_Dict, State]) ->
+    format_state(State).
+
+%% Internal functions.
+
+%% @doc Validates options and sets options to the state.
+%% @private
+-spec init(term(), module(), term(), options()) ->
+    {ok, state()} | {error, term()}.
+init(Ref, Master, MasterOptions, Options) ->
+    Funs = [fun master_hosts/1,
+            fun request_options/1,
+            fun max_num_resubscribe/1,
+            fun resubscribe_interval/1],
+    case options(Funs, Options) of
+        {ok, ValidOptions} ->
+            State = state(Ref, Master, ValidOptions),
+            case init(MasterOptions, State) of
+                {ok, State1} ->
+                    subscribe(State1);
+                {stop, Reason} ->
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% @doc Returns master hosts.
+%% @private
+-spec master_hosts(options()) ->
+    {ok, {master_hosts, [binary()]}} | {error, {bad_master_host, term()}} |
+    {error, {bad_master_hosts, term()}}.
+master_hosts(Options) ->
+    case proplists:get_value(master_hosts, Options, ?DEFAULT_MASTER_HOSTS) of
+        MasterHosts when is_list(MasterHosts) andalso length(MasterHosts) > 0 ->
+            case master_hosts(MasterHosts, []) of
+                {ok, ValidMasterHosts} ->
+                    {ok, {master_hosts, ValidMasterHosts}};
+                {error, MasterHost} ->
+                    {error, {bad_master_host, MasterHost}}
+            end;
+        MasterHosts ->
+            {error, {bad_master_hosts, MasterHosts}}
+    end.
+
+%% @doc Validates and converts master hosts.
+%% @private
+-spec master_hosts([term()], [binary()]) -> {ok, [binary()]} | {error, term()}.
+master_hosts([MasterHost | MasterHosts], ValidMasterHosts)
+  when is_binary(MasterHost) ->
+    master_hosts(MasterHosts, [MasterHost | ValidMasterHosts]);
+master_hosts([MasterHost | MasterHosts], ValidMasterHosts)
+  when is_list(MasterHost) ->
+    master_hosts(MasterHosts, [list_to_binary(MasterHost) | ValidMasterHosts]);
+master_hosts([MasterHost | _MasterHosts], _ValidMasterHosts) ->
+    {error, MasterHost};
+master_hosts([], ValidMasterHosts) ->
+    {ok, lists:reverse(ValidMasterHosts)}.
+
+%% @doc Returns request options.
+%% @private
+-spec request_options(options()) ->
+    {ok, {request_options, [{atom(), term()}]}} |
+    {error, {bad_request_options, term()}}.
+request_options(Options) ->
+    case proplists:get_value(request_options, Options,
+                             ?DEFAULT_REQUEST_OPTIONS) of
+        RequestOptions when is_list(RequestOptions) ->
+            {ok, {request_options, RequestOptions}};
+        RequestOptions ->
+            {error, {bad_request_options, RequestOptions}}
+    end.
+
+%% @doc Returns maximum number of resubscribe.
+%% @private
+-spec max_num_resubscribe(options()) ->
+    {ok, {max_num_resubscribe, non_neg_integer() | infinity}} |
+    {error, {bad_max_num_resubscribe, term()}}.
+max_num_resubscribe(Options) ->
+    case proplists:get_value(max_num_resubscribe, Options,
+                             ?DEFAULT_MAX_NUM_RESUBSCRIBE) of
+        MaxNumResubscribe
+          when is_integer(MaxNumResubscribe) andalso MaxNumResubscribe >= 0 ->
+            {ok, {max_num_resubscribe, MaxNumResubscribe}};
+        MaxNumResubscribe ->
+            {error, {bad_max_num_resubscribe, MaxNumResubscribe}}
+    end.
+
+%% @doc Returns resubscribe interval.
+%% @private
+-spec resubscribe_interval(options()) ->
+    {ok, {resubscribe_interval, non_neg_integer()}} |
+    {error, {bad_resubscribe_interval, term()}}.
+resubscribe_interval(Options) ->
+    case proplists:get_value(resubscribe_interval, Options,
+                             ?DEFAULT_RESUBSCRIBE_INTERVAL) of
+        ResubscribeInterval
+          when is_integer(ResubscribeInterval) andalso
+               ResubscribeInterval >= 0 ->
+            {ok, {resubscribe_interval, ResubscribeInterval}};
+        ResubscribeInterval ->
+            {error, {bad_resubscribe_interval, ResubscribeInterval}}
+    end.
+
+%% @doc Returns validated options.
+%% @private
+-spec options([fun((options()) -> {ok, {atom(), term()}} | {error, term()})],
+              options()) ->
+    {ok, options()} | {error, term()}.
+options(Funs, Options) when is_list(Options) ->
+    options(Funs, Options, []);
+options(_Funs, Options) ->
+    {error, {bad_options, Options}}.
+
+%% @doc Returns validated options.
+%% @private
+-spec options([fun((options()) -> {ok, {atom(), term()}} | {error, term()})],
+              options(), options()) ->
+    {ok, options()} | {error, term()}.
+options([Fun | Funs], Options, ValidOptions) ->
+    case Fun(Options) of
+        {ok, Option} ->
+            options(Funs, Options, [Option | ValidOptions]);
+        {error, Reason} ->
+            {error, Reason}
+    end;
+options([], _Options, ValidOptions) ->
+    {ok, ValidOptions}.
+
+%% @doc Returns state.
+%% @private
+-spec state(term(), module(), options()) -> state().
+state(Ref, Master, Options) ->
+    MasterHosts = proplists:get_value(master_hosts, Options),
+    RequestOptions = proplists:get_value(request_options, Options),
+    MaxNumResubscribe = proplists:get_value(max_num_resubscribe, Options),
+    ResubscribeInterval = proplists:get_value(resubscribe_interval, Options),
+    #state{ref = Ref,
+           master = Master,
+           data_format = ?DATA_FORMAT,
+           data_format_module = ?DATA_FORMAT_MODULE,
+           api_version = ?API_VERSION,
+           master_hosts = MasterHosts,
+           request_options = RequestOptions,
+           max_num_resubscribe = MaxNumResubscribe,
+           resubscribe_interval = ResubscribeInterval}.
+
+%% @doc Calls Master:init/1.
+%% @private
+-spec init(term(), state()) -> {ok, state()} | {stop, term()}.
+init(MasterOptions, #state{master_hosts = MasterHosts,
+                              master = Master} = State) ->
+    case Master:init(MasterOptions) of
+        {ok, MasterState} ->
+            {ok, State#state{master_state = MasterState,
+                             master_hosts_queue = MasterHosts}};
+        {stop, Reason} ->
+            {stop, Reason}
+    end.
+
+%% @doc Sends subscribe requests.
+%% @private
+-spec subscribe(state()) -> {ok, state()} | {error, bad_hosts}.
+subscribe(#state{master_hosts_queue = [MasterHost | MasterHostsQueue]} =
+          State) ->
+    log_info("Try to subscribe.", "Host: ~s.", [MasterHost], State),
+    MasterInfo = master_info(State),
+    MasterInfo1 = MasterInfo#master_info{master_host = MasterHost},
+    case erl_mesos_master_call:subscribe(MasterInfo1) of
+        {ok, ClientRef} ->
+            State1 = State#state{master_hosts_queue = MasterHostsQueue,
+                                 master_host = MasterHost,
+                                 client_ref = ClientRef},
+            State2 = set_recv_timer(State1),
+            {ok, State2};
+        {error, Reason} ->
+            log_error("Can not subscribe.", "Host: ~s, Error reason ~p.",
+                      [MasterHost, Reason], State),
+            State1 = State#state{master_hosts_queue = MasterHostsQueue},
+            subscribe(State1)
+    end;
+subscribe(#state{master_hosts_queue = []}) ->
+    {error, bad_hosts}.
+
+%% @doc Sets recv timer.
+%% @private
+-spec set_recv_timer(state()) -> state().
+set_recv_timer(#state{request_options = RequestOptions} = State) ->
+    RecvTimeout = proplists:get_value(recv_timeout, RequestOptions,
+                                      ?DEFAULT_RECV_TIMEOUT),
+    set_recv_timer(RecvTimeout, State).
+
+%% @doc Sets recv timer.
+%% @private
+-spec set_recv_timer(infinity, state()) -> state().
+set_recv_timer(infinity, State) ->
+    State;
+set_recv_timer(Timeout, State) ->
+    RecvTimerRef = erlang:start_timer(Timeout, self(), recv),
+    State#state{recv_timer_ref = RecvTimerRef}.
+
+%% @doc Returns master info.
+%% @private
+-spec master_info(state()) -> master_info().
+master_info(#state{data_format = DataFormat,
+                   data_format_module = DataFormatModule,
+                   api_version = ApiVersion,
+                   master_host = MasterHost,
+                   request_options = RequestOptions,
+                   subscribe_state = SubscribeState}) ->
+    Subscribed = SubscribeState =:= subscribed,
+    #master_info{data_format = DataFormat,
+                 data_format_module = DataFormatModule,
+                 api_version = ApiVersion,
+                 master_host = MasterHost,
+                 request_options = RequestOptions,
+                 subscribed = Subscribed}.
+
+%% @doc Handles async response.
+%% @private
+-spec handle_async_response(term(), state()) ->
+    {noreply, state()} | {stop, term(), state()}.
+handle_async_response({status, Status, _Message},
+                      #state{subscribe_state = undefined} = State) ->
+    SubscribeResponse = #subscribe_response{status = Status},
+    {noreply, State#state{subscribe_state = SubscribeResponse}};
+handle_async_response({headers, Headers},
+                      #state{subscribe_state =
+                             #subscribe_response{headers = undefined} =
+                             SubscribeResponse} = State) ->
+    SubscribeResponse1 = SubscribeResponse#subscribe_response{headers =
+                                                              Headers},
+    {noreply, State#state{subscribe_state = SubscribeResponse1}};
+handle_async_response(Body,
+                      #state{data_format = DataFormat,
+                             recv_timer_ref = RecvTimerRef,
+                             subscribe_state =
+                             #subscribe_response{status = 200,
+                                                 headers = Headers}} = State)
+  when is_binary(Body) ->
+    ContentType = proplists:get_value(<<"Content-Type">>, Headers),
+    case erl_mesos_data_format:content_type(DataFormat) of
+        ContentType ->
+            cancel_recv_timer(RecvTimerRef),
+            handle_events(Body, State);
+        _ContentType ->
+            log_error("Invalid content type.", "Content type: ~s.",
+                      [ContentType], State),
+            handle_unsubscribe(State)
+    end;
+handle_async_response(Events, #state{subscribe_state = subscribed} = State)
+  when is_binary(Events) ->
+    handle_events(Events, State);
+handle_async_response(_Body,
+                      #state{recv_timer_ref = RecvTimerRef,
+                             subscribe_state =
+                             #subscribe_response{status = 307}} = State) ->
+    cancel_recv_timer(RecvTimerRef),
+    handle_redirect(State);
+handle_async_response(Body,
+                      #state{subscribe_state =
+                             #subscribe_response{status = Status}} = State) ->
+    log_error("Invalid http response.", "Status: ~p, Body: ~s.", [Status, Body],
+              State),
+    handle_unsubscribe(State);
+handle_async_response(done, State) ->
+    log_error("Connection closed.", State),
+    handle_unsubscribe(State);
+handle_async_response({error, Reason}, State) ->
+    log_error("Connection error.", "Reason: ~p.", [Reason], State),
+    handle_unsubscribe(State).
+
+%% @doc Cancels recv timer.
+%% @private
+-spec cancel_recv_timer(undefined | reference()) ->
+    undefined | false | non_neg_integer().
+cancel_recv_timer(undefined) ->
+    undefined;
+cancel_recv_timer(RecvTimerRef) ->
+    erlang:cancel_timer(RecvTimerRef).
+
+%% @doc Handles list of events.
+%% @private
+-spec handle_events(binary(), state()) ->
+    {noreply, state()} | {stop, term(), state()}.
+handle_events(Events, #state{data_format = DataFormat,
+                             data_format_module = DataFormatModule} = State) ->
+    Messages = erl_mesos_data_format:decode_events(DataFormat, DataFormatModule,
+                                                   Events),
+    case apply_events(Messages, State) of
+        {ok, State1} ->
+            {noreply, State1};
+        {stop, State1} ->
+            {stop, shutdown, State1}
+    end.
+
+%% @doc Applies list of events.
+%% @private
+-spec apply_events([erl_mesos_data_format:message()], state()) ->
+    {ok, state()} | {stop, state()}.
+apply_events([Message | Messages], State) ->
+    case apply_event(Message, State) of
+        {ok, State1} ->
+            apply_events(Messages, State1);
+        {stop, State1} ->
+            {stop, State1}
+    end;
+apply_events([], State) ->
+    {ok, State}.
+
+%% @doc Applies event.
+%% @private
+-spec apply_event(erl_mesos_data_format:message(), state()) ->
+    {ok, state()} | {stop, state()}.
+apply_event(Message, #state{master_host = MasterHost,
+                            registered = Registered,
+                            subscribe_state = SubscribeState} = State) ->
+    case Message of
+        #'Event'{type = 'SUBSCRIBED',
+                 subscribed = EventSubscribed}
+          when is_record(SubscribeState, subscribe_response), not Registered ->
+            log_info("Successfully subscribed.", "Host: ~s.", [MasterHost],
+                     State),
+            {EventSubscribed1, State1} = set_subscribed(EventSubscribed, State),
+            call(registered, EventSubscribed1, State1#state{registered = true});
+        #'Event'{type = 'SUBSCRIBED',
+                 subscribed = EventSubscribed}
+          when is_record(SubscribeState, subscribe_response) ->
+            log_info("Successfully resubscribed.", "Host: ~s.", [MasterHost],
+                     State),
+            {_EventSubscribed, State1} = set_subscribed(EventSubscribed, State),
+            call(reregistered, State1);
+        #'Event'{type = 'TASK_ADDED', task_added = TaskAdded} ->
+            call(task_added, TaskAdded, State);
+        #'Event'{type = 'TASK_UPDATED', task_updated = TaskUpdated} ->
+            call(offer_rescinded, TaskUpdated, State)
+    end.
+
+%% @doc Sets subscribed state.
+%% @private
+-spec set_subscribed('Event.Subscribed'(), state()) ->
+    {'Event.Subscribed'(), state()}.
+set_subscribed(EventSubscribed,
+               #state{call_subscribe = CallSubscribe} =
+               State) ->
+    State1 = State#state{call_subscribe = CallSubscribe,
+                         master_hosts_queue = undefined,
+                         subscribe_state = subscribed,
+                         num_redirect = 0,
+                         num_resubscribe = 0},
+    {EventSubscribed, State1}.
+
+%% @doc Calls Master:Callback/2.
+%% @private
+-spec call(atom(), state()) -> {ok, state()} | {stop, state()}.
+call(Callback, #state{master = Master,
+                      master_state = MasterState} = State) ->
+    MasterInfo = master_info(State),
+    case Master:Callback(MasterInfo, MasterState) of
+        {ok, MasterState1} ->
+            {ok, State#state{master_state = MasterState1}};
+        {stop, MasterState1} ->
+            {stop, State#state{master_state = MasterState1}}
+    end.
+
+%% @doc Calls Master:Callback/3.
+%% @private
+-spec call(atom(), term(), state()) -> {ok, state()} | {stop, state()}.
+call(Callback, Arg, #state{master = Master,
+                           master_state = MasterState} = State) ->
+    MasterInfo = master_info(State),
+    case Master:Callback(MasterInfo, Arg, MasterState) of
+        {ok, MasterState1} ->
+            {ok, State#state{master_state = MasterState1}};
+        {stop, MasterState1} ->
+            {stop, State#state{master_state = MasterState1}}
+    end.
+
+%% @doc Handles unsubscribe.
+%% @private
+-spec handle_unsubscribe(state()) ->
+    {noreply, state()} | {stop, term(), state()}.
+handle_unsubscribe(#state{registered = false,
+                          client_ref = ClientRef,
+                          recv_timer_ref = RecvTimerRef} = State) ->
+    case subscribe(State) of
+        {ok, State1} ->
+            close(ClientRef),
+            cancel_recv_timer(RecvTimerRef),
+            State2 = State1#state{client_ref = undefined,
+                                  subscribe_state = undefined},
+            {noreply, State2};
+        {error, Reason} ->
+            {stop, {shutdown, {subscribe, {error, Reason}}}, State}
+    end;
+handle_unsubscribe(#state{recv_timer_ref = RecvTimerRef,
+                          subscribe_state = subscribed} = State) ->
+    State1 = State#state{subscribe_state = undefined},
+    case call(disconnected, State1) of
+        {ok, #state{master_hosts = MasterHosts,
+                    master_host = MasterHost} = State2} ->
+            cancel_recv_timer(RecvTimerRef),
+            MasterHostsQueue = lists:delete(MasterHost, MasterHosts),
+            State3 = State2#state{master_hosts_queue = MasterHostsQueue},
+            start_resubscribe_timer(State3);
+        {stop, State1} ->
+            {stop, shutdown, State1}
+    end;
+handle_unsubscribe(#state{recv_timer_ref = RecvTimerRef} = State) ->
+    cancel_recv_timer(RecvTimerRef),
+    State1 = State#state{subscribe_state = undefined},
+    start_resubscribe_timer(State1).
+
+%% @doc Start resubscribe timer.
+%% @private
+-spec start_resubscribe_timer(state()) ->
+    {noreply, state()} | {stop, term(), state()}.
+start_resubscribe_timer(#state{max_num_resubscribe = 0} = State) ->
+    {stop, {shutdown, {resubscribe, {error, max_num_resubscribe}}}, State};
+start_resubscribe_timer(#state{max_num_resubscribe = MaxNumResubscribe,
+                               master_hosts_queue = [],
+                               num_resubscribe = MaxNumResubscribe} = State) ->
+    {stop, {shutdown, {resubscribe, {error, max_num_resubscribe}}}, State};
+start_resubscribe_timer(#state{max_num_resubscribe = MaxNumResubscribe,
+                               master_hosts_queue =
+                               [MasterHost | MasterHostsQueue],
+                               client_ref = ClientRef,
+                               num_resubscribe = MaxNumResubscribe} = State) ->
+    close(ClientRef),
+    State1 = State#state{master_hosts_queue = MasterHostsQueue,
+                         master_host = MasterHost,
+                         client_ref = undefined,
+                         num_resubscribe = 1},
+    State2 = set_resubscribe_timer(State1),
+    {noreply, State2};
+start_resubscribe_timer(#state{client_ref = ClientRef,
+                               num_resubscribe = NumResubscribe} = State) ->
+    close(ClientRef),
+    State1 = State#state{client_ref = undefined,
+                         num_resubscribe = NumResubscribe + 1},
+    State2 = set_resubscribe_timer(State1),
+    {noreply, State2}.
+
+%% @doc Sets resubscribe timer.
+%% @private
+-spec set_resubscribe_timer(state()) -> state().
+set_resubscribe_timer(#state{resubscribe_interval = ResubscribeInterval} =
+                      State) ->
+    ResubscribeTimerRef = erlang:start_timer(ResubscribeInterval, self(),
+                                             resubscribe),
+    State#state{resubscribe_timer_ref = ResubscribeTimerRef}.
+
+%% @doc Sends resubscribe requests.
+%% @private
+-spec resubscribe(state()) -> {noreply, state()} | {stop, term(), state()}.
+resubscribe(#state{master_host = MasterHost} = State) ->
+    log_info("Try to resubscribe.", "Host: ~s.", [MasterHost], State),
+    MasterInfo = master_info(State),
+    case erl_mesos_master_call:subscribe(MasterInfo) of
+        {ok, ClientRef} ->
+            State1 = State#state{client_ref = ClientRef},
+            State2 = set_recv_timer(State1),
+            {noreply, State2};
+        {error, Reason} ->
+            log_error("Can not resubscribe.", "Host: ~s, Error reason: ~p.",
+                      [MasterHost, Reason], State),
+            handle_unsubscribe(State)
+    end.
+
+%% @doc Handles redirect.
+%% @private
+-spec handle_redirect(state()) -> {noreply, state()} | {stop, term(), state()}.
+handle_redirect(#state{master_hosts = MasterHosts,
+                       request_options = RequestOptions,
+                       master_hosts_queue = MasterHostsQueue,
+                       master_host = MasterHost,
+                       registered = Registered,
+                       client_ref = ClientRef,
+                       subscribe_state =
+                       #subscribe_response{headers = Headers},
+                       num_redirect = NumRedirect} = State) ->
+    case proplists:get_value(max_redirect, RequestOptions,
+                             ?DEFAULT_MAX_REDIRECT) of
+        NumRedirect when not Registered ->
+            {stop, {shutdown, {subscribe, {error, max_redirect}}}, State};
+        NumRedirect ->
+            {stop, {shutdown, {resubscribe, {error, max_redirect}}}, State};
+        _MaxNumRedirect ->
+            close(ClientRef),
+            MasterHost1 = redirect_master_host(Headers),
+            log_info("Redirect.", "Form host: ~s, to host: ~s.",
+                     [MasterHost, MasterHost1], State),
+            MasterHosts1 = [MasterHost1 | lists:delete(MasterHost1,
+                                                       MasterHosts)],
+            MasterHostsQueue1 = [MasterHost1 | lists:delete(MasterHost,
+                                                            MasterHostsQueue)],
+            State1 = State#state{master_hosts = MasterHosts1,
+                                 master_hosts_queue = MasterHostsQueue1,
+                                 subscribe_state = undefined,
+                                 num_redirect = NumRedirect + 1},
+            redirect(State1)
+    end.
+
+%% @doc Returns redirect master host.
+%% @private
+-spec redirect_master_host(erl_mesos_http:headers()) -> binary().
+redirect_master_host(Headers) ->
+    case proplists:get_value(<<"Location">>, Headers) of
+        <<"//", MasterHost/binary>> ->
+            [MasterHost1 | _Path] = binary:split(MasterHost, <<"/">>),
+            MasterHost1;
+        MasterHost ->
+            MasterHost
+    end.
+
+%% @doc Calls subscribe/1 or resubscribe/1.
+%% @private
+-spec redirect(state()) -> {noreply, state()} | {stop, term(), state()}.
+redirect(#state{registered = false} = State) ->
+    case subscribe(State) of
+        {ok, State1} ->
+            {noreply, State1};
+        {error, Reason} ->
+            {stop, {shutdown, {subscribe, {error, Reason}}}, State}
+    end;
+redirect(#state{master_hosts_queue = [MasterHost | MasterHostsQueue]} =
+         State) ->
+    State1 = State#state{master_hosts_queue = MasterHostsQueue,
+                         master_host = MasterHost,
+                         num_resubscribe = 0},
+    resubscribe(State1).
+
+%% @doc Calls Master:handle_info/3.
+%% @private
+-spec call_handle_info(term(), state()) ->
+    {noreply, state()} | {stop, shutdown, state()}.
+call_handle_info(Info, State) ->
+    case call(handle_info, Info, State) of
+        {ok, State1} ->
+            {noreply, State1};
+        {stop, State1} ->
+            {stop, shutdown, State1}
+    end.
+
+%% @doc Closes the connection.
+%% @private
+-spec close(undefined | erl_mesos_http:client_ref()) -> ok | {error, term()}.
+close(undefined) ->
+    ok;
+close(ClientRef) ->
+    erl_mesos_http:close_async_response(ClientRef).
+
+%% @doc Logs info.
+%% @private
+-spec log_info(string(), string(), [term()], state()) -> ok.
+log_info(Message, Format, Data, #state{ref = Ref, master = Master}) ->
+    erl_mesos_logger:info(Message ++ " Ref: ~p, Master: ~p, " ++ Format,
+                          [Ref, Master | Data]).
+
+%% @doc Logs warning.
+%% @private
+-spec log_warning(string(), string(), [term()], state()) -> ok.
+log_warning(Message, Format, Data, #state{ref = Ref, master = Master}) ->
+    erl_mesos_logger:warning(Message ++ " Ref: ~p, Master: ~p, " ++ Format,
+                             [Ref, Master | Data]).
+
+%% @doc Logs error.
+%% @private
+-spec log_error(string(), state()) -> ok.
+log_error(Message, #state{ref = Ref, master = Master}) ->
+    erl_mesos_logger:error(Message ++ " Ref: ~p, Master: ~p.",
+                           [Ref, Master]).
+
+%% @doc Logs error.
+%% @private
+-spec log_error(string(), string(), [term()], state()) -> ok.
+log_error(Message, Format, Data, #state{ref = Ref, master = Master}) ->
+    erl_mesos_logger:error(Message ++ " Ref: ~p, Master: ~p, " ++ Format,
+                           [Ref, Master | Data]).
+
+%% @doc Formats state.
+%% @private
+-spec format_state(state()) -> [{string(), [{atom(), term()}]}].
+format_state(#state{ref = Ref,
+                    master = Master,
+                    data_format = DataFormat,
+                    data_format_module = DataFormatModule,
+                    api_version = ApiVersion,
+                    master_hosts = MasterHosts,
+                    request_options = RequestOptions,
+                    max_num_resubscribe = MaxNumResubscribe,
+                    resubscribe_interval = ResubscribeInterval,
+                    registered = Registered,
+                    call_subscribe = CallSubscribe,
+                    master_state = MasterState,
+                    master_hosts_queue = MasterHostsQueue,
+                    master_host = MasterHost,
+                    client_ref = ClientRef,
+                    recv_timer_ref = RecvTimerRef,
+                    subscribe_state = SubscribeState,
+                    num_redirect = NumRedirect,
+                    num_resubscribe = NumResubscribe,
+                    resubscribe_timer_ref = ResubscribeTimerRef}) ->
+    State = [{data_format, DataFormat},
+             {data_format_module, DataFormatModule},
+             {api_version, ApiVersion},
+             {master_hosts, MasterHosts},
+             {request_options, RequestOptions},
+             {max_num_resubscribe, MaxNumResubscribe},
+             {resubscribe_interval, ResubscribeInterval},
+             {registered, Registered},
+             {call_subscribe, CallSubscribe},
+             {master_hosts_queue, MasterHostsQueue},
+             {master_host, MasterHost},
+             {client_ref, ClientRef},
+             {recv_timer_ref, RecvTimerRef},
+             {subscribe_state, SubscribeState},
+             {num_redirect, NumRedirect},
+             {num_resubscribe, NumResubscribe},
+             {resubscribe_timer_ref, ResubscribeTimerRef}],
+    [{"Ref", Ref},
+     {"Master", Master},
+     {"Master state", MasterState},
+     {"State", State}].

--- a/src/erl_mesos_master.erl
+++ b/src/erl_mesos_master.erl
@@ -657,14 +657,7 @@ apply_event(Message, #state{master_host = MasterHost,
             log_info("Successfully subscribed.", "Host: ~s.", [MasterHost],
                      State),
             {EventSubscribed1, State1} = set_subscribed(EventSubscribed, State),
-            call(registered, EventSubscribed1, State1#state{registered = true});
-        #'Event'{type = 'SUBSCRIBED',
-                 subscribed = EventSubscribed}
-          when is_record(SubscribeState, subscribe_response) ->
-            log_info("Successfully resubscribed.", "Host: ~s.", [MasterHost],
-                     State),
-            {_EventSubscribed, State1} = set_subscribed(EventSubscribed, State),
-            call(reregistered, State1);
+            call(subscribed, EventSubscribed1, State1#state{registered = true});
         #'Event'{type = 'TASK_ADDED', task_added = TaskAdded} ->
             call(task_added, TaskAdded, State);
         #'Event'{type = 'TASK_UPDATED', task_updated = TaskUpdated} ->

--- a/src/erl_mesos_master_call.erl
+++ b/src/erl_mesos_master_call.erl
@@ -119,8 +119,8 @@ async_request(#master_info{data_format = DataFormat,
 -spec sync_request(erl_mesos_master:master_info(),
                    erl_mesos_master:'Call'()) ->
     ok | {error, term()}.
-sync_request(#master_info{subscribed = false}, _Call) ->
-    {error, not_subscribed};
+%% sync_request(#master_info{subscribed = false}, _Call) ->
+%%     {error, not_subscribed};
 sync_request(#master_info{data_format = DataFormat,
                           data_format_module = DataFormatModule,
                           api_version = ApiVersion,

--- a/src/erl_mesos_master_call.erl
+++ b/src/erl_mesos_master_call.erl
@@ -103,7 +103,7 @@ get_master(MasterInfo) ->
 %% @doc Sends async http request.
 %% @private
 -spec async_request(erl_mesos_master:master_info(),
-                    erl_mesos_scheduler:'Call'()) ->
+                    erl_mesos_master:'Call'()) ->
     {ok, erl_mesos_http:client_ref()} | {error, term()}.
 async_request(#master_info{data_format = DataFormat,
                            data_format_module = DataFormatModule,
@@ -117,7 +117,7 @@ async_request(#master_info{data_format = DataFormat,
 %% @doc Sends sync http request.
 %% @private
 -spec sync_request(erl_mesos_master:master_info(),
-                   erl_mesos_scheduler:'Call'()) ->
+                   erl_mesos_master:'Call'()) ->
     ok | {error, term()}.
 sync_request(#master_info{subscribed = false}, _Call) ->
     {error, not_subscribed};
@@ -130,7 +130,11 @@ sync_request(#master_info{data_format = DataFormat,
     ReqHeaders = [],
     Response = erl_mesos_http:sync_request(ReqUrl, DataFormat, DataFormatModule,
                                            ReqHeaders, Call, RequestOptions),
-    erl_mesos_http:handle_sync_response(Response).
+    case erl_mesos_http:handle_sync_response(Response) of
+        {ok, Body} ->
+            erl_mesos_data_format:decode(DataFormat, DataFormatModule, Body, 'Response');
+        Error -> Error
+    end.
 
 %% @doc Returns request url.
 %% @private

--- a/src/erl_mesos_master_call.erl
+++ b/src/erl_mesos_master_call.erl
@@ -1,0 +1,139 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License. You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @private
+
+-module(erl_mesos_master_call).
+
+-include("master_info.hrl").
+
+-include("master_protobuf.hrl").
+
+-export([subscribe/1,
+         get_version/1,
+         get_state/1,
+         get_agents/1,
+         get_frameworks/1,
+         get_executors/1,
+         get_tasks/1,
+         get_roles/1,
+         get_master/1]).
+
+-type version() :: v1.
+-export_type([version/0]).
+
+-define(V1_API_PATH, "/api/v1").
+
+%% External functions.
+
+%% @doc Executes subscribe call.
+-spec subscribe(erl_mesos_master:master_info()) ->
+    {ok, erl_mesos_http:client_ref()} | {error, term()}.
+subscribe(MasterInfo) ->
+    Call = #'Call'{type = 'SUBSCRIBE'},
+    async_request(MasterInfo, Call).
+
+%% @doc Executes GetVersion call.
+-spec get_version(erl_mesos_master:master_info()) -> term() | {error, term()}.
+get_version(MasterInfo) ->
+    Call = #'Call'{type = 'GET_VERSION'},
+    sync_request(MasterInfo, Call).
+
+%% @doc Executes GetState call.
+-spec get_state(erl_mesos_master:master_info()) -> term() | {error, term()}.
+get_state(MasterInfo) ->
+    Call = #'Call'{type = 'GET_STATE'},
+    sync_request(MasterInfo, Call).
+
+%% @doc Executes GetAgents call.
+-spec get_agents(erl_mesos_master:master_info()) -> term() | {error, term()}.
+get_agents(MasterInfo) ->
+    Call = #'Call'{type = 'GET_AGENTS'},
+    sync_request(MasterInfo, Call).
+
+%% @doc Executes GetFrameworks call.
+-spec get_frameworks(erl_mesos_master:master_info()) -> term() | {error, term()}.
+get_frameworks(MasterInfo) ->
+    Call = #'Call'{type = 'GET_FRAMEWORKS'},
+    sync_request(MasterInfo, Call).
+
+%% @doc Executes GetExecutors call.
+-spec get_executors(erl_mesos_master:master_info()) -> term() | {error, term()}.
+get_executors(MasterInfo) ->
+    Call = #'Call'{type = 'GET_EXECUTORS'},
+    sync_request(MasterInfo, Call).
+
+%% @doc Executes GetTasks call.
+-spec get_tasks(erl_mesos_master:master_info()) -> term() | {error, term()}.
+get_tasks(MasterInfo) ->
+    Call = #'Call'{type = 'GET_TASKS'},
+    sync_request(MasterInfo, Call).
+
+%% @doc Executes GetRoles call.
+-spec get_roles(erl_mesos_master:master_info()) -> term() | {error, term()}.
+get_roles(MasterInfo) ->
+    Call = #'Call'{type = 'GET_ROLES'},
+    sync_request(MasterInfo, Call).
+
+%% @doc Executes GetMaster call.
+-spec get_master(erl_mesos_master:master_info()) -> term() | {error, term()}.
+get_master(MasterInfo) ->
+    Call = #'Call'{type = 'GET_MASTER'},
+    sync_request(MasterInfo, Call).
+
+%% Internal functions.
+
+%% @doc Sends async http request.
+%% @private
+-spec async_request(erl_mesos_master:master_info(),
+                    erl_mesos_scheduler:'Call'()) ->
+    {ok, erl_mesos_http:client_ref()} | {error, term()}.
+async_request(#master_info{data_format = DataFormat,
+                           data_format_module = DataFormatModule,
+                           api_version = ApiVersion,
+                           master_host = MasterHost,
+                           request_options = RequestOptions}, Call) ->
+    ReqUrl = request_url(ApiVersion, MasterHost),
+    erl_mesos_http:async_request(ReqUrl, DataFormat, DataFormatModule, [], Call,
+                                 RequestOptions).
+
+%% @doc Sends sync http request.
+%% @private
+-spec sync_request(erl_mesos_master:master_info(),
+                   erl_mesos_scheduler:'Call'()) ->
+    ok | {error, term()}.
+sync_request(#master_info{subscribed = false}, _Call) ->
+    {error, not_subscribed};
+sync_request(#master_info{data_format = DataFormat,
+                          data_format_module = DataFormatModule,
+                          api_version = ApiVersion,
+                          master_host = MasterHost,
+                          request_options = RequestOptions}, Call) ->
+    ReqUrl = request_url(ApiVersion, MasterHost),
+    ReqHeaders = [],
+    Response = erl_mesos_http:sync_request(ReqUrl, DataFormat, DataFormatModule,
+                                           ReqHeaders, Call, RequestOptions),
+    erl_mesos_http:handle_sync_response(Response).
+
+%% @doc Returns request url.
+%% @private
+-spec request_url(version(), binary()) -> binary().
+request_url(v1, MasterHost) ->
+    <<"http://", MasterHost/binary, ?V1_API_PATH>>.

--- a/src/erl_mesos_master_manager.erl
+++ b/src/erl_mesos_master_manager.erl
@@ -1,0 +1,170 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License. You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @privat
+
+-module(erl_mesos_master_manager).
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+
+-export([start_master/5, stop_master/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {monitors = [] :: [{{reference(), pid()}, term()}]}).
+
+-type state() :: #state{}.
+
+-define(TAB, erl_mesos_masters).
+
+%% External functions.
+
+%% @doc Starts the `erl_mesos_master_manager' process.
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, {}, []).
+
+%% @doc Starts the `erl_mesos_master' process.
+-spec start_master(term(), module(), term(),
+                      erl_mesos_master:options(), timeout()) ->
+    {ok, pid()} | {error, term()}.
+start_master(Ref, Master, MasterOptions, Options, Timeout) ->
+    gen_server:call(?MODULE, {start_master, Ref, Master, MasterOptions,
+                              Options}, Timeout).
+
+%% @doc Stops the `erl_mesos_master' process.
+-spec stop_master(term()) -> ok | {error, term()}.
+stop_master(Ref) ->
+    gen_server:call(?MODULE, {stop_master, Ref}).
+
+%% gen_server callback functions.
+
+%% @private
+-spec init({}) -> {ok, state()}.
+init({}) ->
+    Monitors = [{{erlang:monitor(process, Pid), Pid}, Ref} || [Ref, Pid] <-
+                ets:match(erl_mesos_masters, {{'$1', pid}, '$2'})],
+    {ok, #state{monitors = Monitors}}.
+
+%% @private
+-spec handle_call(term(), {pid(), term()}, state()) ->
+    {reply, ok | {ok, pid()} | {error, term()}, state()} | {noreply, state()}.
+handle_call({start_master, Ref, Master, MasterOptions, Options},
+            _From, #state{monitors = Monitors} = State) ->
+    case get_master_option(Ref, pid) of
+        {ok, Pid} ->
+            {reply, {error, {already_started, Pid}}, State};
+        not_found ->
+            case erl_mesos_master_sup:start_master(Ref, Master,
+                                                         MasterOptions,
+                                                         Options) of
+                {ok, Pid} ->
+                    set_master(Ref, Pid, Master, MasterOptions,
+                                  Options),
+                    Monitor = {{erlang:monitor(process, Pid), Pid}, Ref},
+                    {reply, {ok, Pid},
+                     State#state{monitors = [Monitor | Monitors]}};
+                {error, Reason} ->
+                    {reply, {error, Reason}, State}
+            end
+    end;
+handle_call({stop_master, Ref}, _From, State) ->
+    case get_master_option(Ref, pid) of
+        {ok, Pid} ->
+            case erl_mesos_master_sup:stop_master(Pid) of
+                ok ->
+                    {reply, ok, State};
+                {error, Reason} ->
+                    {reply, {error, Reason}, State}
+            end;
+        not_found ->
+            {reply, {error, not_found}, State}
+    end;
+handle_call(Request, _From, State) ->
+    erl_mesos_logger:warning("Master manager received unexpected call "
+                             "request. Request: ~p.", [Request]),
+    {noreply, State}.
+
+%% @private
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(Request, State) ->
+    erl_mesos_logger:warning("Master manager received unexpected cast "
+                             "request. Request: ~p.", [Request]),
+    {noreply, State}.
+
+%% @private
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info({'DOWN', MonitorRef, process, Pid, _Reason},
+            #state{monitors = Monitors} = State) ->
+    {_, Ref} = lists:keyfind({MonitorRef, Pid}, 1, Monitors),
+    Monitors1 = lists:keydelete({MonitorRef, Pid}, 1, Monitors),
+    remove_master(Ref),
+    {noreply, State#state{monitors = Monitors1}};
+handle_info(Request, State) ->
+    erl_mesos_logger:warning("Master manager received unexpected "
+                             "message. Message: ~p.", [Request]),
+    {noreply, State}.
+
+%% @private
+-spec terminate(term(), state()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+-spec code_change(term(), state(), term()) -> {ok, state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% Internal functions.
+
+%% @doc Returns master option.
+%% @private
+-spec get_master_option(term(), atom()) -> {ok, term()} | not_found.
+get_master_option(Ref, Key) ->
+    case ets:lookup(?TAB, {Ref, Key}) of
+        [{{Ref, Key}, Value}] ->
+            {ok, Value};
+        [] ->
+            not_found
+    end.
+
+%% @doc Sets master.
+%% @private
+-spec set_master(term(), pid(), module(), term(),
+                    erl_mesos_master:options()) ->
+    true.
+set_master(Ref, Pid, Master, MasterOptions, Options) ->
+    ets:insert(?TAB, {{Ref, pid}, Pid}),
+    ets:insert(?TAB, {{Ref, master}, Master}),
+    ets:insert(?TAB, {{Ref, master_options}, MasterOptions}),
+    ets:insert(?TAB, {{Ref, options}, Options}).
+
+%% @doc Removes master.
+%% @private
+-spec remove_master(reference()) -> true.
+remove_master(Ref) ->
+    ets:match_delete(?TAB, {{Ref, '$1'}, '$2'}).

--- a/test/erl_mesos_cluster/cluster.sh
+++ b/test/erl_mesos_cluster/cluster.sh
@@ -62,8 +62,7 @@ function start {
 
 function stop {
     docker_compose_path=$(script_dir)"/cluster.yml"
-    docker-compose -f "$docker_compose_path" kill
-    docker-compose -f "$docker_compose_path" rm -f --all
+    docker-compose -f "$docker_compose_path" down
 }
 
 function restart {
@@ -78,6 +77,11 @@ function stop_master {
 function stop_slave {
     docker kill erl_mesos_slave
     docker rm erl_mesos_slave
+}
+
+function ps {
+    docker_compose_path=$(script_dir)"/cluster.yml"
+    docker-compose -f "$docker_compose_path" ps
 }
 
 case "$1" in
@@ -98,6 +102,9 @@ case "$1" in
         ;;
     stop_slave)
         stop_slave
+        ;;
+    ps)
+        ps
         ;;
     *)
         echo $"Usage: $0 {build|start|stop|restart|stop_master ID|stop_slave}"

--- a/test/erl_mesos_master_SUITE.erl
+++ b/test/erl_mesos_master_SUITE.erl
@@ -1,0 +1,337 @@
+-module(erl_mesos_master_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-include_lib("master_info.hrl").
+
+-include_lib("master_protobuf.hrl").
+
+-export([all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2]).
+
+-export([subscribed/1,
+         disconnected/1,
+         get_version/1,
+         get_state/1,
+         get_agents/1,
+         get_frameworks/1,
+         get_executors/1,
+         get_tasks/1,
+         get_roles/1,
+         get_master/1,
+         task_added/1,
+         task_updated/1]).
+
+-define(LOG, false).
+
+all() ->
+    [{group, mesos_cluster, [sequence]}].
+
+groups() ->
+    [{mesos_cluster, [subscribed,
+                      disconnected,
+                      task_added,
+                      task_updated,
+                      get_version,
+                      get_state,
+                      get_agents,
+                      get_frameworks,
+                      get_executors,
+                      get_tasks,
+                      get_roles,
+                      get_master]}].
+
+init_per_suite(Config) ->
+    ok = erl_mesos:start(),
+    Master = erl_mesos_test_master,
+    MasterOptions = [],
+    {ok, Masters} = erl_mesos_cluster:config(masters, Config),
+    MasterHosts = [MasterHost || {_Container, MasterHost} <- Masters],
+    Options = [{master_hosts, MasterHosts}],
+    [{log, ?LOG},
+     {master, Master},
+     {master_options, MasterOptions},
+     {options, Options} |
+     Config].
+
+end_per_suite(_Config) ->
+    application:stop(erl_mesos),
+    ok.
+
+init_per_group(mesos_cluster, Config) ->
+    Config.
+
+end_per_group(mesos_cluster, _Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) ->
+    case lists:member(TestCase, proplists:get_value(mesos_cluster, groups())) of
+        true ->
+            stop_mesos_cluster(Config),
+            start_mesos_cluster(Config),
+            Config;
+        false ->
+            Config
+    end.
+
+end_per_testcase(TestCase, Config) ->
+    case lists:member(TestCase, proplists:get_value(mesos_cluster, groups())) of
+        true ->
+            stop_mesos_cluster(Config),
+            Config;
+        false ->
+            Config
+    end.
+
+%% Test functions.
+
+%% Callbacks.
+
+subscribed(Config) ->
+    log("Subscribed test cases.", Config),
+    Ref = {erl_mesos_master, subscribed},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {_, MasterInfo, EventSubscribed}} = recv_reply(subscribed),
+    %% Test master info.
+    #master_info{master_host = MasterHost,
+                    subscribed = true} = MasterInfo,
+    MasterHosts = proplists:get_value(master_hosts, Options),
+    true = lists:member(binary_to_list(MasterHost), MasterHosts),
+    %% Test event subscribed.
+    #'Event.Subscribed'{get_state = _State} =
+        EventSubscribed,
+    ok = stop_master(Ref, Config).
+
+disconnected(Config) ->
+    log("Disconnected test cases.", Config),
+    Ref = {erl_mesos_master, disconnected},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    Options1 = [{max_num_resubscribe, 0} | Options],
+    %% Test connection crash.
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options1,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    Pid = response_pid(),
+    exit(Pid, kill),
+    {disconnected, {MasterPid, MasterInfo}} = recv_reply(disconnected),
+    %% Test master info.
+    #master_info{master_host = MasterHost,
+                 subscribed = false} = MasterInfo,
+    MasterHosts = proplists:get_value(master_hosts, Options),
+    true = lists:member(binary_to_list(MasterHost), MasterHosts),
+    %% Test cluster stop.
+    Ref1 = {erl_mesos_master, disconnected, 1},
+    {ok, _} = start_master(Ref1, Master, MasterOptions1, Options1,
+                           Config),
+    {subscribed, {MasterPid1, _, _}} = recv_reply(subscribed),
+    erl_mesos_cluster:stop(Config),
+    {disconnected, {MasterPid1, MasterInfo1}} = recv_reply(disconnected),
+    %% Test master info.
+    #master_info{master_host = MasterHost1,
+                 subscribed = false} = MasterInfo1,
+    true = lists:member(binary_to_list(MasterHost1), MasterHosts).
+
+task_added(Config) ->
+    log("Task Added test cases.", Config),
+    Ref = {erl_mesos_master, subscribed},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                           Config),
+    {subscribed, {_, _MasterInfo, _EventSubscribed}} = recv_reply(subscribed),
+    %% Get task added...
+    %% Test event task added.
+    %% #'Event.TaskAdded'{task = _Task} =
+    %%     EventTaskAdded,
+    ok = stop_master(Ref, Config).
+
+task_updated(Config) ->
+    log("Task Updated test cases.", Config),
+    Ref = {erl_mesos_master, subscribed},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                           Config),
+    {subscribed, {_, _MasterInfo, _EventSubscribed}} = recv_reply(subscribed),
+    %% Get task updated...
+    %% Test event task updated.
+    %% #'Event.TaskUpdated'{} =
+    %%     EventTaskUpdated,
+    ok = stop_master(Ref, Config).
+
+get_version(Config) ->
+    log("Get version test cases.", Config),
+    Ref = {erl_mesos_master, get_version},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    MasterPid ! get_version,
+    {get_version, #'Response'{}} = recv_reply(get_version),
+    MasterPid ! get_master_info,
+    {get_master_info, MasterInfo} =
+        recv_reply(get_master_info),
+    %% Test master info.
+    #master_info{subscribed = true} = MasterInfo,
+    ok = stop_master(Ref, Config).
+
+get_state(Config) ->
+    log("Get state test cases.", Config),
+    Ref = {erl_mesos_master, get_state},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    MasterPid ! get_state,
+    {get_state, #'Response'{}} = recv_reply(get_state),
+    ok = stop_master(Ref, Config).
+
+get_agents(Config) ->
+    log("Get agents test cases.", Config),
+    Ref = {erl_mesos_master, get_agents},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    MasterPid ! get_agents,
+    {get_agents, #'Response'{}} = recv_reply(get_agents),
+    ok = stop_master(Ref, Config).
+
+get_frameworks(Config) ->
+    log("Get frameworks test cases.", Config),
+    Ref = {erl_mesos_master, get_frameworks},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    MasterPid ! get_frameworks,
+    {get_frameworks, #'Response'{}} = recv_reply(get_frameworks),
+    ok = stop_master(Ref, Config).
+
+get_executors(Config) ->
+    log("Get executors test cases.", Config),
+    Ref = {erl_mesos_master, get_executors},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    MasterPid ! get_executors,
+    {get_executors, #'Response'{}} = recv_reply(get_executors),
+    ok = stop_master(Ref, Config).
+
+get_tasks(Config) ->
+    log("Get tasks test cases.", Config),
+    Ref = {erl_mesos_master, get_tasks},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    MasterPid ! get_tasks,
+    {get_tasks, #'Response'{}} = recv_reply(get_tasks),
+    ok = stop_master(Ref, Config).
+
+get_roles(Config) ->
+    log("Get roles test cases.", Config),
+    Ref = {erl_mesos_master, get_roles},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    MasterPid ! get_roles,
+    {get_roles, #'Response'{}} = recv_reply(get_roles),
+    ok = stop_master(Ref, Config).
+
+get_master(Config) ->
+    log("Get master test cases.", Config),
+    Ref = {erl_mesos_master, get_master},
+    Master = ?config(master, Config),
+    MasterOptions = ?config(master_options, Config),
+    MasterOptions1 = set_test_pid(MasterOptions),
+    Options = ?config(options, Config),
+    {ok, _} = start_master(Ref, Master, MasterOptions1, Options,
+                              Config),
+    {subscribed, {MasterPid, _, _}} = recv_reply(subscribed),
+    MasterPid ! get_master,
+    {get_master, #'Response'{}} = recv_reply(get_master),
+    ok = stop_master(Ref, Config).
+
+%% Internal functions.
+
+start_mesos_cluster(Config) ->
+    log("Start test mesos cluster.", Config),
+    erl_mesos_cluster:start(Config),
+    {ok, StartTimeout} = erl_mesos_cluster:config(start_timeout, Config),
+    timer:sleep(StartTimeout).
+
+stop_mesos_cluster(Config) ->
+    log("Stop test mesos cluster.", Config),
+    erl_mesos_cluster:stop(Config).
+
+start_master(Ref, Master, MasterOptions, Options, Config) ->
+    log("Start master. Ref: ~p, Master: ~p.", [Ref, Master], Config),
+    erl_mesos:start_master(Ref, Master, MasterOptions, Options).
+
+stop_master(Ref, Config) ->
+    log("Stop scheduler. Ref: ~p.", [Ref], Config),
+    erl_mesos:stop_master(Ref).
+
+set_test_pid(MasterOptions) ->
+    [{test_pid, self()} | MasterOptions].
+
+response_pid() ->
+    [{ClientRef, _Request} | _] = ets:tab2list(hackney_manager),
+    {ok, Pid} = hackney_manager:async_response_pid(ClientRef),
+    Pid.
+
+recv_reply(Reply) ->
+    erl_mesos_test_utils:recv_reply(Reply).
+
+log(Format, Config) ->
+    log(Format, [], Config).
+
+log(Format, Data, Config) ->
+    case ?config(log, Config) of
+        true ->
+            ct:pal(Format, Data);
+        false ->
+            ok
+    end.

--- a/test/erl_mesos_test_master.erl
+++ b/test/erl_mesos_test_master.erl
@@ -1,0 +1,91 @@
+-module(erl_mesos_test_master).
+
+-include_lib("master_info.hrl").
+
+-include_lib("master_protobuf.hrl").
+
+-export([init/1,
+         subscribed/3,
+         disconnected/2,
+         task_added/3,
+         task_updated/3,
+         handle_info/3,
+         terminate/3]).
+
+-record(state, {test_pid}).
+
+%% erl_mesos_master callback functions.
+
+init(Options) ->
+    TestPid = proplists:get_value(test_pid, Options),
+    {ok, #state{test_pid = TestPid}}.
+
+subscribed(MasterInfo, EventSubscribed,
+           #state{test_pid = TestPid} = State) ->
+    reply(TestPid, subscribed, {self(), MasterInfo, EventSubscribed}),
+    {ok, State}.
+
+task_added(MasterInfo, EventTaskAdded,
+           #state{test_pid = TestPid} = State) ->
+    reply(TestPid, task_added, {self(), MasterInfo, EventTaskAdded}),
+    {ok, State}.
+
+task_updated(MasterInfo, EventTaskUpdated,
+           #state{test_pid = TestPid} = State) ->
+    reply(TestPid, task_updated, {self(), MasterInfo, EventTaskUpdated}),
+    {ok, State}.
+
+disconnected(MasterInfo, #state{test_pid = TestPid} = State) ->
+    reply(TestPid, disconnected, {self(), MasterInfo}),
+    {ok, State}.
+
+handle_info(MasterInfo, get_version, #state{test_pid = TestPid} = State) ->
+    Data = erl_mesos_master:get_version(MasterInfo),
+    reply(TestPid, get_version, Data),
+    {ok, State};
+handle_info(MasterInfo, get_state, #state{test_pid = TestPid} = State) ->
+    Data = erl_mesos_master:get_state(MasterInfo),
+    reply(TestPid, get_state, Data),
+    {ok, State};
+handle_info(MasterInfo, get_agents, #state{test_pid = TestPid} = State) ->
+    Data = erl_mesos_master:get_agents(MasterInfo),
+    reply(TestPid, get_agents, Data),
+    {ok, State};
+handle_info(MasterInfo, get_frameworks, #state{test_pid = TestPid} = State) ->
+    Data = erl_mesos_master:get_frameworks(MasterInfo),
+    reply(TestPid, get_frameworks, Data),
+    {ok, State};
+handle_info(MasterInfo, get_executors, #state{test_pid = TestPid} = State) ->
+    Data = erl_mesos_master:get_executors(MasterInfo),
+    reply(TestPid, get_executors, Data),
+    {ok, State};
+handle_info(MasterInfo, get_tasks, #state{test_pid = TestPid} = State) ->
+    Data = erl_mesos_master:get_tasks(MasterInfo),
+    reply(TestPid, get_tasks, Data),
+    {ok, State};
+handle_info(MasterInfo, get_roles, #state{test_pid = TestPid} = State) ->
+    Data = erl_mesos_master:get_roles(MasterInfo),
+    reply(TestPid, get_roles, Data),
+    {ok, State};
+handle_info(MasterInfo, get_master, #state{test_pid = TestPid} = State) ->
+    Data = erl_mesos_master:get_master(MasterInfo),
+    reply(TestPid, get_master, Data),
+    {ok, State};
+handle_info(MasterInfo, get_master_info, #state{test_pid = TestPid} = State) ->
+    Data = MasterInfo,
+    reply(TestPid, get_master_info, Data),
+    {ok, State};
+handle_info(_MasterInfo, stop, State) ->
+    {stop, State};
+handle_info(_MasterInfo, _Info, State) ->
+    {ok, State}.
+
+terminate(MasterInfo, Reason, #state{test_pid = TestPid} = State) ->
+    reply(TestPid, terminate, {self(), MasterInfo, Reason, State}).
+
+%% Internal functions.
+
+reply(undefined, _Name, _Message) ->
+    undefined;
+reply(TestPid, Name, Data) ->
+    TestPid ! {Name, Data}.


### PR DESCRIPTION
This adds a subscriber + sync requests for the master [operator api](https://mesos.apache.org/documentation/latest/operator-http-api/) (`erl_mesos_master.erl`) as well as a sync request based agent operator api ('erl_mesos_agent.

**TODO**:

- [ ] Cleanup
- [ ] Tests